### PR TITLE
add map_path_prefixes arg to py_wheel

### DIFF
--- a/examples/wheel/BUILD
+++ b/examples/wheel/BUILD
@@ -159,6 +159,38 @@ py_wheel(
 )
 
 py_wheel(
+    name = "custom_package_root_map_prefixes",
+    distribution = "custom_package_root_map_prefixes",
+    python_tag = "py3",
+    map_path_prefixes = [
+        "examples/wheel/lib=custom_path_prefix", # like strip_path_prefixes, order matters here
+        "examples/wheel=custom_path_prefix",
+    ],
+    version = "0.0.1",
+    deps = [
+        ":example_pkg"
+    ]
+)
+
+py_wheel(
+    name = "custom_package_root_strip_and_map_prefixes",
+    distribution = "custom_package_root_strip_and_map_prefixes",
+    python_tag = "py3",
+    strip_path_prefixes = [
+        "examples/wheel"
+    ],
+    map_path_prefixes = [
+        "examples/wheel/lib=custom_path_prefix", # has no effect because "examples/wheel" is stripped beforehand
+        "/lib=/custom_lib", # maps stripped prefix to a custom prefix
+        "=custom_prefix_after_stripping"  # prepends custom prefix
+    ],
+    version = "0.0.1",
+    deps = [
+        ":example_pkg"
+    ]
+)
+
+py_wheel(
     name = "python_requires_in_a_package",
     distribution = "example_python_requires_in_a_package",
     python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
@@ -196,6 +228,8 @@ py_test(
         ":custom_package_root",
         ":custom_package_root_multi_prefix",
         ":custom_package_root_multi_prefix_reverse_order",
+        ":custom_package_root_map_prefixes",
+        ":custom_package_root_strip_and_map_prefixes",
         ":customized",
         ":minimal_with_py_library",
         ":minimal_with_py_package",

--- a/examples/wheel/README.md
+++ b/examples/wheel/README.md
@@ -1,1 +1,10 @@
 This is a sample description of a wheel.
+
+### py_wheel directory structure
+The py_wheel target offers two means of directly manipulating the directory structure of the output .whl: `strip_path_prefixes` and `map_path_prefixes`. These allow you to use your own convention for the package directories, similar to the use of [distutils `package_dir`](https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages).
+
+#### strip_path_prefixes
+This argument takes in a list of strings representing prefixes to strip from your .whl. Each prefix will be stripped from each filename in the order that the prefixes are listed. You can see this in the targets `:custom_package_root`, `:custom_package_root_multi_prefix`, and `:custom_package_root_multi_prefix_reverse_order`.
+
+#### map_path_prefixes
+This argument takes in a list of strings in the format 'key=value' where the `key` represents a prefix to be stripped out and the `value` represents a string to replace that prefix with. Note that the `map_path_prefixes` argument will always execute after the `strip_path_prefixes` argument. You can see examples of `map_path_prefixes` in the targets `:custom_package_root_map_prefixes` and `:custom_package_root_strip_and_map_prefixes`.

--- a/examples/wheel/wheel_test.py
+++ b/examples/wheel/wheel_test.py
@@ -163,6 +163,40 @@ second = second.main:s""")
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/METADATA',
                  'example_custom_package_root_multi_prefix_reverse_order-0.0.1.dist-info/RECORD'])
 
+    def test_custom_package_root_map_prefixes_wheel(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'rules_python',
+                                'examples', 'wheel',
+                                'custom_package_root_map_prefixes-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['custom_path_prefix/data.txt',
+                 'custom_path_prefix/module_with_data.py',
+                 'custom_path_prefix/simple_module.py',
+                 'custom_path_prefix/main.py',
+                 'custom_package_root_map_prefixes-0.0.1.dist-info/WHEEL',
+                 'custom_package_root_map_prefixes-0.0.1.dist-info/METADATA',
+                 'custom_package_root_map_prefixes-0.0.1.dist-info/RECORD'])
+
+    def test_custom_package_root_strip_and_map_prefixes(self):
+        filename = os.path.join(os.environ['TEST_SRCDIR'],
+                                'rules_python',
+                                'examples', 'wheel',
+                                'custom_package_root_strip_and_map_prefixes-0.0.1-py3-none-any.whl')
+
+        with zipfile.ZipFile(filename) as zf:
+            self.assertEquals(
+                zf.namelist(),
+                ['custom_prefix_after_stripping/custom_lib/data.txt',
+                 'custom_prefix_after_stripping/custom_lib/module_with_data.py',
+                 'custom_prefix_after_stripping/custom_lib/simple_module.py',
+                 'custom_prefix_after_stripping/main.py',
+                 'custom_package_root_strip_and_map_prefixes-0.0.1.dist-info/WHEEL',
+                 'custom_package_root_strip_and_map_prefixes-0.0.1.dist-info/METADATA',
+                 'custom_package_root_strip_and_map_prefixes-0.0.1.dist-info/RECORD'])
+
     def test_python_requires_wheel(self):
         filename = os.path.join(os.environ['TEST_SRCDIR'],
                                 'rules_python',

--- a/python/packaging.bzl
+++ b/python/packaging.bzl
@@ -115,6 +115,7 @@ def _py_wheel_impl(ctx):
     args.add("--platform", ctx.attr.platform)
     args.add("--out", outfile.path)
     args.add_all(ctx.attr.strip_path_prefixes, format_each = "--strip_path_prefix=%s")
+    args.add_all(ctx.attr.map_path_prefixes, format_each = "--map_path_prefix=%s")
 
     args.add("--input_file_list", packageinputfile)
 
@@ -267,6 +268,10 @@ _other_attrs = {
         default = [],
         doc = "path prefixes to strip from files added to the generated package",
     ),
+    "map_path_prefixes": attr.string_list(
+        default = [],
+        doc = "key=value formatted list of prefixes to map to new prefixes for files added to the generated package"
+    )
 }
 
 py_wheel = rule(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Does not include precompiled binaries, eg. `.par` files. See [CONTRIBUTING.md](https://github.com/bazelbuild/rules_python/blob/master/CONTRIBUTING.md) for info
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

py_wheel targets have a strip_path_prefixes argument, but not a map_path_prefixes argument.

Issue Number: N/A


## What is the new behavior?

py_wheel targets now have a map_path_prefixes argument, which allows developers to alter the prefixes within their wheels by passing in an array of '='-separated key-value pairs. this makes it easier for people shipping python wheels out of larger repositories to pull in dependencies from other directories.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

